### PR TITLE
Add Shepherd Fund

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,3 +2,5 @@
   changes:
     added:
     - Shepherd Fund (base contribution only)
+    changed:
+    - Replaced unnecessary np.where calls in eligibility checks

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Shepherd Fund (base contribution only)

--- a/policyengine_it/parameters/private/shepherd_fund/base_amount.yaml
+++ b/policyengine_it/parameters/private/shepherd_fund/base_amount.yaml
@@ -1,12 +1,7 @@
-description: Base amount for Shepherd Fund
-brackets:
-  - threshold:
-      2024-01-01: 0
-    amount:
-      2024-01-01: 464.81
+description: Shepherd Fund base amount that all contributors pay
+values:
+  0000-01-01: 464.81
 
 metadata:
-  type: single_amount
-  rate_unit: currency-EUR
-  threshold_unit: currency-EUR
-  label: Shepherd Fund base contribution
+  unit: currency-EUR
+  label: Shepherd Fund base amount

--- a/policyengine_it/parameters/private/shepherd_fund/base_amount.yaml
+++ b/policyengine_it/parameters/private/shepherd_fund/base_amount.yaml
@@ -1,0 +1,12 @@
+description: Base amount for Shepherd Fund
+brackets:
+  - threshold:
+      2024-01-01: 0
+    amount:
+      2024-01-01: 464.81
+
+metadata:
+  type: single_amount
+  rate_unit: currency-EUR
+  threshold_unit: currency-EUR
+  label: Shepherd Fund base contribution

--- a/policyengine_it/parameters/private/shepherd_fund/eligibility.yaml
+++ b/policyengine_it/parameters/private/shepherd_fund/eligibility.yaml
@@ -1,0 +1,7 @@
+description: Shepherd Fund eligible employees
+values:
+  0000-01-01: [EXECUTIVE]
+
+metadata:
+  unit: currency-EUR
+  label: Shepherd Fund eligibility

--- a/policyengine_it/tests/private/shepherd_fund/shepherd_fund_base_amount.yaml
+++ b/policyengine_it/tests/private/shepherd_fund/shepherd_fund_base_amount.yaml
@@ -1,0 +1,23 @@
+- name: Standard employee
+  period: 2024
+  input:
+    employment_category: EMPLOYEE
+    total_individual_pre_tax_income: 15_000
+  output:
+    shepherd_fund_base_amount: 0
+
+- name: Executive with lower income
+  period: 2024
+  input:
+    employment_category: EXECUTIVE
+    total_individual_pre_tax_income: 15_000
+  output:
+    shepherd_fund_base_amount: 464.81
+
+- name: Executive with higher income
+  period: 2024
+  input:
+    employment_category: EXECUTIVE
+    total_individual_pre_tax_income: 150_000
+  output:
+    shepherd_fund_base_amount: 464.81

--- a/policyengine_it/tests/private/shepherd_fund/shepherd_fund_eligible.yaml
+++ b/policyengine_it/tests/private/shepherd_fund/shepherd_fund_eligible.yaml
@@ -1,0 +1,20 @@
+- name: Standard employee is not eligible
+  period: 2024
+  input:
+    employment_category: EMPLOYEE
+  output:
+    shepherd_fund_eligible: false
+
+- name: UNEMPLOYED is not eligible
+  period: 2024
+  input:
+    employment_category: UNEMPLOYED
+  output:
+    shepherd_fund_eligible: false
+  
+- name: EXECUTIVE is eligible
+  period: 2024
+  input:
+    employment_category: EXECUTIVE
+  output:
+    shepherd_fund_eligible: true

--- a/policyengine_it/variables/gov/insurance_and_pensions.py
+++ b/policyengine_it/variables/gov/insurance_and_pensions.py
@@ -7,4 +7,4 @@ class insurance_and_pensions(Variable):
     label = "insurance and pensions, total"
     unit = EUR
     definition_period = YEAR
-    adds = ["social_security", "mario_negri", "mario_besusso"]
+    adds = ["social_security", "mario_negri", "mario_besusso", "shepherd_fund"]

--- a/policyengine_it/variables/private/mario_besusso/mario_besusso_eligible.py
+++ b/policyengine_it/variables/private/mario_besusso/mario_besusso_eligible.py
@@ -16,8 +16,4 @@ class mario_besusso_eligible(Variable):
             "employment_category", period
         ).decode_to_str()[0]
 
-        is_eligible = np.where(
-            employment_category in mb_eligible_groups, True, False
-        )
-
-        return is_eligible
+        return employment_category in mb_eligible_groups

--- a/policyengine_it/variables/private/mario_negri/mario_negri_eligible.py
+++ b/policyengine_it/variables/private/mario_negri/mario_negri_eligible.py
@@ -14,8 +14,4 @@ class mario_negri_eligible(Variable):
             "employment_category", period
         ).decode_to_str()[0]
 
-        is_eligible = np.where(
-            employment_category in mn_eligible_groups, True, False
-        )
-
-        return is_eligible
+        return employment_category in mn_eligible_groups

--- a/policyengine_it/variables/private/shepherd_fund/shepherd_fund_base_amount.py
+++ b/policyengine_it/variables/private/shepherd_fund/shepherd_fund_base_amount.py
@@ -1,0 +1,14 @@
+from policyengine_it.model_api import *
+
+
+class shepherd_fund_base_amount(Variable):
+    value_type = float
+    entity = Person
+    label = "Fixed, flat base amount paid by all Shepherd Fund contributors"
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        is_eligible = person("shepherd_fund_eligible", period)
+        base_amount = parameters(period).private.shepherd_fund.base_amount
+
+        return is_eligible * base_amount

--- a/policyengine_it/variables/private/shepherd_fund/shepherd_fund_eligible.py
+++ b/policyengine_it/variables/private/shepherd_fund/shepherd_fund_eligible.py
@@ -1,0 +1,23 @@
+from policyengine_it.model_api import *
+
+
+class shepherd_fund_eligible(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for Shepherd Fund"
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        sf_eligible_groups = parameters(
+            period
+        ).private.shepherd_fund.eligibility
+
+        employment_category = person(
+            "employment_category", period
+        ).decode_to_str()[0]
+
+        is_eligible = np.where(
+            employment_category in sf_eligible_groups, True, False
+        )
+
+        return is_eligible

--- a/policyengine_it/variables/private/shepherd_fund/shepherd_fund_eligible.py
+++ b/policyengine_it/variables/private/shepherd_fund/shepherd_fund_eligible.py
@@ -16,8 +16,4 @@ class shepherd_fund_eligible(Variable):
             "employment_category", period
         ).decode_to_str()[0]
 
-        is_eligible = np.where(
-            employment_category in sf_eligible_groups, True, False
-        )
-
-        return is_eligible
+        return employment_category in sf_eligible_groups


### PR DESCRIPTION
Fixes #16 
Fixes #41 

Adds the Shepherd Fund and replaces the unnecessary `np.where` calls in Mario Besusso and Mario Negri eligibility checks