### PR TITLE
Mint GitHub App token in push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -21,12 +21,18 @@ jobs:
       && !(github.event.head_commit.message == 'Update PolicyEngine Italy')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -42,6 +48,8 @@ jobs:
           committer_name: Github Actions[bot]
           author_name: Github Actions[bot]
           message: Update PolicyEngine Italy
+          github_token: ${{ steps.app-token.outputs.token }}
+          fetch: false
   Test:
     runs-on: ${{ matrix.os }}
     if: |
@@ -91,15 +99,19 @@ jobs:
       (github.repository == 'PolicyEngine/policyengine-it')
       && (github.event.head_commit.message == 'Update PolicyEngine Italy')
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -111,4 +123,4 @@ jobs:
       - name: Update API
         run: python .github/update_api.py
         env:
-          GITHUB_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Migrated push workflow from the expired POLICYENGINE_GITHUB PAT to a short-lived GitHub App token.


### PR DESCRIPTION
## Summary
- Replace expired `POLICYENGINE_GITHUB` PAT with a short-lived GitHub App token minted via `actions/create-github-app-token@v1` in the `versioning` and `Deploy` jobs
- Pass the App token to `EndBug/add-and-commit@v9` via `github_token:` and add `fetch: false`
- Drop the stale job-level `env.GH_TOKEN` in `Deploy`; `update_api.py` reads `GITHUB_TOKEN` from its step env

Follows the same pattern already landed in `policyengine-core` #470, `microdf` #296, `policyengine-us`, and `policyengine-ng` #26.

## Test plan
- [ ] CI lint/test pass on this PR
- [ ] After merge, the next `Update PolicyEngine Italy` push shows `versioning` and `Deploy` jobs minting a token and succeeding

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>